### PR TITLE
feat: Implements switching between first and third person view

### DIFF
--- a/Ikaros/core/camera_controller.gd
+++ b/Ikaros/core/camera_controller.gd
@@ -2,7 +2,7 @@ class_name IkarosCameraController
 extends Node
 
 
-@export var look_sensitivity: float = 0.5
+@export var mouse_sensitivity: float = 0.5
 @export var joystick_sensitivity: float = 4.0
 
 var camera_root: Node3D
@@ -26,8 +26,8 @@ func _ready() -> void:
 func _unhandled_input(event: InputEvent) -> void:
 	if event is InputEventMouseMotion and Input.mouse_mode == Input.MOUSE_MODE_CAPTURED:
 		var mouse_motion: InputEventMouseMotion = event as InputEventMouseMotion
-		_rotation_input = -mouse_motion.relative.x * look_sensitivity
-		_tilt_input = -mouse_motion.relative.y * look_sensitivity
+		_rotation_input = -mouse_motion.relative.x * mouse_sensitivity
+		_tilt_input = -mouse_motion.relative.y * mouse_sensitivity
 
 
 # TODO: This whole setup is a candidate for a new class (IkarosCamera)

--- a/Ikaros/core/camera_controller.gd
+++ b/Ikaros/core/camera_controller.gd
@@ -18,8 +18,20 @@ extends Node
 @export var tilt_lower_limit: float = -90.0
 
 
-var camera_root: Node3D
-var camera: Camera3D
+## Camera root node. Acts as the camera arm/holder. Defined when accessed if not yet defined.
+var camera_root: Node3D = null:
+	get:
+		if camera_root == null:
+			_create_camera_root()
+		return camera_root
+
+## Camera node. Defined when accessed if not yet defined.
+var camera: Camera3D = null:
+	get:
+		if camera_root == null:
+			_create_camera_root()  # Creating the camera root also creates the camera.
+		return camera
+
 
 var _rotation_input: float
 var _tilt_input: float
@@ -29,7 +41,6 @@ var _camera_rotation: Vector3
 
 func _ready() -> void:
 	assert(get_parent() is IkarosScene)
-	camera_root = _create_camera_root()
 	Input.mouse_mode = Input.MOUSE_MODE_CAPTURED
 
 
@@ -41,14 +52,13 @@ func _unhandled_input(event: InputEvent) -> void:
 
 
 # TODO: This whole setup is a candidate for a new class (IkarosCamera)
-func _create_camera_root() -> Node3D:
+func _create_camera_root() -> void:
 	camera_root = Node3D.new()
 	camera = Camera3D.new()
 	camera_root.add_child(camera)
 	camera.position.z = -camera_distance  # Move camera behind the player
 	camera.rotation_degrees.y = 180.0  # Rotate camera to face the player
 	camera_root.position.y = camera_height  # Move camera root to proper height so the camera isn't underground
-	return camera_root
 
 
 func _process(delta: float) -> void:

--- a/Ikaros/core/camera_controller.gd
+++ b/Ikaros/core/camera_controller.gd
@@ -38,6 +38,18 @@ var _tilt_input: float
 var _mouse_rotation: Vector3
 var _camera_rotation: Vector3
 
+## Controls camera position. Camera position is automatically adjusted when this value changes.
+var _is_first_person: bool = false:
+	set(value):
+		if value == _is_first_person:
+			return
+
+		if value == false:
+			camera.position.z = -camera_distance
+		else:
+			camera.position.z = 0.0  # TODO: Experiment with a small positive value (mimics actual head movement)
+		_is_first_person = value
+
 
 func _ready() -> void:
 	assert(get_parent() is IkarosScene)
@@ -49,6 +61,9 @@ func _unhandled_input(event: InputEvent) -> void:
 		var mouse_motion: InputEventMouseMotion = event as InputEventMouseMotion
 		_rotation_input = -mouse_motion.relative.x * mouse_sensitivity
 		_tilt_input = -mouse_motion.relative.y * mouse_sensitivity
+	elif event is InputEventKey or event is InputEventJoypadButton:
+		if Input.is_action_just_pressed("toggle_camera_view"):
+			_is_first_person = not _is_first_person
 
 
 # TODO: This whole setup is a candidate for a new class (IkarosCamera)

--- a/Ikaros/core/camera_controller.gd
+++ b/Ikaros/core/camera_controller.gd
@@ -35,6 +35,9 @@ func _create_camera_root() -> Node3D:
 	camera_root = Node3D.new()
 	camera = Camera3D.new()
 	camera_root.add_child(camera)
+	camera.position.z = -4.0  # Move camera behind the player
+	camera.rotation_degrees.y = 180.0  # Rotate camera to face the player
+	camera_root.position.y = 1.5  # Move camera root to proper height so the camera isn't underground
 	return camera_root
 
 

--- a/Ikaros/core/camera_controller.gd
+++ b/Ikaros/core/camera_controller.gd
@@ -2,14 +2,24 @@ class_name IkarosCameraController
 extends Node
 
 
+@export_category("Look Sensitivity")
 @export var mouse_sensitivity: float = 0.5
 @export var joystick_sensitivity: float = 4.0
 
+@export_category("Camera Config")
+## Controls camera distance from the camera root.
+## Negative values move the camera ahead of the root.
+@export var camera_distance: float = 4.0
+## Controls camera height.
+@export var camera_height: float = 1.5
+## Controls how high up the camera can rotate to.
+@export var tilt_upper_limit: float = 90.0
+## Controls how low down the camera can rotate to.
+@export var tilt_lower_limit: float = -90.0
+
+
 var camera_root: Node3D
 var camera: Camera3D
-
-var tilt_lower_limit: float = -90.0
-var tilt_upper_limit: float = 90.0
 
 var _rotation_input: float
 var _tilt_input: float
@@ -35,9 +45,9 @@ func _create_camera_root() -> Node3D:
 	camera_root = Node3D.new()
 	camera = Camera3D.new()
 	camera_root.add_child(camera)
-	camera.position.z = -4.0  # Move camera behind the player
+	camera.position.z = -camera_distance  # Move camera behind the player
 	camera.rotation_degrees.y = 180.0  # Rotate camera to face the player
-	camera_root.position.y = 1.5  # Move camera root to proper height so the camera isn't underground
+	camera_root.position.y = camera_height  # Move camera root to proper height so the camera isn't underground
 	return camera_root
 
 

--- a/Ikaros/core/scene.gd
+++ b/Ikaros/core/scene.gd
@@ -31,7 +31,4 @@ func attach_camera_to_player() -> void:
 		_logger.warn("Couldn't attach camera to player: Player queued for free.")
 		return
 
-	camera_controller.camera.position.z = -4.0  # Move camera behind the player
-	camera_controller.camera.rotation_degrees.y = 180.0  # Rotate camera to face the player
-	camera_controller.camera_root.position.y = 1.5  # Move camera root to proper height so the camera isn't underground
 	player.add_child(camera_controller.camera_root)

--- a/Ikaros/project.godot
+++ b/Ikaros/project.godot
@@ -91,6 +91,12 @@ look_down={
 "events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":3,"axis_value":1.0,"script":null)
 ]
 }
+toggle_camera_view={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":86,"key_label":0,"unicode":118,"location":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":4,"pressure":0.0,"pressed":false,"script":null)
+]
+}
 
 [physics]
 


### PR DESCRIPTION
Player can now switch between first and third person view. Currently mapped to `V` on keyboard, and `SELECT` (and equivalents) on controller.

Closes #25 