### PR TITLE
Player movement direction based on camera rotation

### DIFF
--- a/Ikaros/core/camera_controller.gd
+++ b/Ikaros/core/camera_controller.gd
@@ -32,16 +32,10 @@ var camera: Camera3D = null:
 			_create_camera_root()  # Creating the camera root also creates the camera.
 		return camera
 
-var _logger: LogStream = Ikaros.get_logger("CameraController")
-var _rotation_input: float
-var _tilt_input: float
-var _mouse_rotation: Vector3
-var _camera_rotation: Vector3
-
 ## Controls camera position. Camera position is automatically adjusted when this value changes.
-var _is_first_person: bool = false:
+var is_first_person: bool = false:
 	set(value):
-		if value == _is_first_person:
+		if value == is_first_person:
 			return
 
 		if value == false:
@@ -51,7 +45,14 @@ var _is_first_person: bool = false:
 			_logger.debug("Switching to first person view.")
 			# TODO: Experiment with a small positive value (mimics actual head movement)
 			camera.position.z = 0.0
-		_is_first_person = value
+		is_first_person = value
+
+var _logger: LogStream = Ikaros.get_logger("CameraController")
+var _rotation_input: float
+var _tilt_input: float
+var _mouse_rotation: Vector3
+var _camera_rotation: Vector3
+
 
 
 func _ready() -> void:
@@ -66,7 +67,7 @@ func _unhandled_input(event: InputEvent) -> void:
 		_tilt_input = -mouse_motion.relative.y * mouse_sensitivity
 	elif event is InputEventKey or event is InputEventJoypadButton:
 		if Input.is_action_just_pressed("toggle_camera_view"):
-			_is_first_person = not _is_first_person
+			is_first_person = not is_first_person
 
 
 # TODO: This whole setup is a candidate for a new class (IkarosCamera)

--- a/Ikaros/core/camera_controller.gd
+++ b/Ikaros/core/camera_controller.gd
@@ -54,7 +54,6 @@ var _mouse_rotation: Vector3
 var _camera_rotation: Vector3
 
 
-
 func _ready() -> void:
 	assert(get_parent() is IkarosScene)
 	Input.mouse_mode = Input.MOUSE_MODE_CAPTURED

--- a/Ikaros/core/camera_controller.gd
+++ b/Ikaros/core/camera_controller.gd
@@ -73,6 +73,7 @@ func _unhandled_input(event: InputEvent) -> void:
 func _create_camera_root() -> void:
 	_logger.info("Creating camera root and camera.")
 	camera_root = Node3D.new()
+	camera_root.name = "CameraRoot"
 	camera = Camera3D.new()
 	camera_root.add_child(camera)
 	# Move camera to proper distance from root

--- a/Ikaros/core/player_controller.gd
+++ b/Ikaros/core/player_controller.gd
@@ -8,7 +8,7 @@ var _camera_root: Node3D = null:
 	get:
 		if _player == null:
 			return null
-		elif _camera_root == null:
+		if _camera_root == null:
 			_camera_root = _player.find_child("CameraRoot")
 		return _camera_root
 
@@ -16,7 +16,7 @@ var _col_shape: CollisionShape3D = null:
 	get:
 		if _player == null:
 			return null
-		elif _col_shape == null:
+		if _col_shape == null:
 			_col_shape = _player.find_child("CollisionShape3D")
 		return _col_shape
 

--- a/Ikaros/core/player_controller.gd
+++ b/Ikaros/core/player_controller.gd
@@ -2,6 +2,7 @@ class_name IkarosPlayerController
 extends Node
 
 var _player: IkarosCharacter
+var _direction: Vector3
 
 var _jump_command: IkarosCharacterJumpCommand
 var _move_command: IkarosCharacterMoveCommand
@@ -22,16 +23,16 @@ func _process(_delta: float) -> void:
 	var input_dir: Vector2 = Input.get_vector(
 		"move_right", "move_left", "move_backward", "move_forward"
 	)
-	var direction: Vector3
-	direction = (_player.transform.basis * Vector3(input_dir.x, 0, input_dir.y)).limit_length()
-	if direction:
+
+	_direction = (_player.transform.basis * Vector3(input_dir.x, 0, input_dir.y)).limit_length()
+	if _direction:
 		# HACK: Rotate the player character's collision shape to match with camera node.
 		# This will rotate the mesh as well. Cursed af, but works for now.
 		var camera_root: Node3D = _player.find_child("CameraRoot")
 		var col_shape: CollisionShape3D = _player.find_child("CollisionShape3D")
 		col_shape.rotation.y = camera_root.rotation.y
 
-		var relative_dir: Vector3 = direction.rotated(Vector3.UP, camera_root.rotation.y)
+		var relative_dir: Vector3 = _direction.rotated(Vector3.UP, camera_root.rotation.y)
 		_move_params.direction = relative_dir
 		_move_command.execute(_player, _move_params)
 

--- a/Ikaros/core/player_controller.gd
+++ b/Ikaros/core/player_controller.gd
@@ -25,8 +25,8 @@ func _process(_delta: float) -> void:
 	var direction: Vector3
 	direction = (_player.transform.basis * Vector3(input_dir.x, 0, input_dir.y)).limit_length()
 	if direction:
-		# HACK: Rotate the player character's collision shape to match with camera node. This will rotate the mesh as well.
-		# Cursed af, but works for now.
+		# HACK: Rotate the player character's collision shape to match with camera node.
+		# This will rotate the mesh as well. Cursed af, but works for now.
 		var camera_root: Node3D = _player.find_child("CameraRoot")
 		var col_shape: CollisionShape3D = _player.find_child("CollisionShape3D")
 		col_shape.rotation.y = camera_root.rotation.y

--- a/Ikaros/core/player_controller.gd
+++ b/Ikaros/core/player_controller.gd
@@ -3,6 +3,7 @@ extends Node
 
 var _player: IkarosCharacter
 var _direction: Vector3
+
 var _camera_root: Node3D = null:
 	get:
 		if _player == null:
@@ -10,6 +11,14 @@ var _camera_root: Node3D = null:
 		elif _camera_root == null:
 			_camera_root = _player.find_child("CameraRoot")
 		return _camera_root
+
+var _col_shape: CollisionShape3D = null:
+	get:
+		if _player == null:
+			return null
+		elif _col_shape == null:
+			_col_shape = _player.find_child("CollisionShape3D")
+		return _col_shape
 
 var _jump_command: IkarosCharacterJumpCommand
 var _move_command: IkarosCharacterMoveCommand
@@ -35,8 +44,7 @@ func _process(_delta: float) -> void:
 	if _direction:
 		# HACK: Rotate the player character's collision shape to match with camera node.
 		# This will rotate the mesh as well. Cursed af, but works for now.
-		var col_shape: CollisionShape3D = _player.find_child("CollisionShape3D")
-		col_shape.rotation.y = _camera_root.rotation.y
+		_col_shape.rotation.y = _camera_root.rotation.y
 
 		var relative_dir: Vector3 = _direction.rotated(Vector3.UP, _camera_root.rotation.y)
 		_move_params.direction = relative_dir

--- a/Ikaros/core/player_controller.gd
+++ b/Ikaros/core/player_controller.gd
@@ -4,6 +4,8 @@ extends Node
 var _player: IkarosCharacter
 var _direction: Vector3
 
+var _camera_controller: IkarosCameraController
+
 var _camera_root: Node3D = null:
 	get:
 		if _player == null:
@@ -41,11 +43,18 @@ func _process(_delta: float) -> void:
 	)
 
 	_direction = (_player.transform.basis * Vector3(input_dir.x, 0, input_dir.y)).limit_length()
-	if _direction:
-		# HACK: Rotate the player character's collision shape to match with camera node.
-		# This will rotate the mesh as well. Cursed af, but works for now.
+
+	# HACK: Rotate the player character's collision shape to match with camera node.
+	# This will rotate the mesh as well. Cursed af, but works for now.
+	# BUG: Player rotates to face camera when switching view. Should be the other way,
+	# so we should rotate the camera to match player character orientation.
+	if _camera_controller.is_first_person:
 		_col_shape.rotation.y = _camera_root.rotation.y
 
+	if not _camera_controller.is_first_person and _direction:
+		_col_shape.rotation.y = _camera_root.rotation.y
+
+	if _direction:
 		var relative_dir: Vector3 = _direction.rotated(Vector3.UP, _camera_root.rotation.y)
 		_move_params.direction = relative_dir
 		_move_command.execute(_player, _move_params)
@@ -57,4 +66,5 @@ func _process(_delta: float) -> void:
 func _ready() -> void:
 	assert(get_parent() is IkarosScene)
 	var scene: IkarosScene = get_parent()
+	_camera_controller = scene.find_child("IkarosCameraController")
 	_player = scene.player

--- a/Ikaros/core/player_controller.gd
+++ b/Ikaros/core/player_controller.gd
@@ -29,7 +29,7 @@ func _process(_delta: float) -> void:
 		# Cursed af, but works for now.
 		var camera_root: Node3D = _player.find_child("CameraRoot")
 		var col_shape: CollisionShape3D = _player.find_child("CollisionShape3D")
-		col_shape.rotation.y = camera_root.rotation.y  # CRITICAL: Doesn't work
+		col_shape.rotation.y = camera_root.rotation.y
 
 		var relative_dir: Vector3 = direction.rotated(Vector3.UP, camera_root.rotation.y)
 		_move_params.direction = relative_dir

--- a/Ikaros/core/player_controller.gd
+++ b/Ikaros/core/player_controller.gd
@@ -3,6 +3,13 @@ extends Node
 
 var _player: IkarosCharacter
 var _direction: Vector3
+var _camera_root: Node3D = null:
+	get:
+		if _player == null:
+			return null
+		elif _camera_root == null:
+			_camera_root = _player.find_child("CameraRoot")
+		return _camera_root
 
 var _jump_command: IkarosCharacterJumpCommand
 var _move_command: IkarosCharacterMoveCommand
@@ -28,11 +35,10 @@ func _process(_delta: float) -> void:
 	if _direction:
 		# HACK: Rotate the player character's collision shape to match with camera node.
 		# This will rotate the mesh as well. Cursed af, but works for now.
-		var camera_root: Node3D = _player.find_child("CameraRoot")
 		var col_shape: CollisionShape3D = _player.find_child("CollisionShape3D")
-		col_shape.rotation.y = camera_root.rotation.y
+		col_shape.rotation.y = _camera_root.rotation.y
 
-		var relative_dir: Vector3 = _direction.rotated(Vector3.UP, camera_root.rotation.y)
+		var relative_dir: Vector3 = _direction.rotated(Vector3.UP, _camera_root.rotation.y)
 		_move_params.direction = relative_dir
 		_move_command.execute(_player, _move_params)
 

--- a/Ikaros/core/player_controller.gd
+++ b/Ikaros/core/player_controller.gd
@@ -25,7 +25,14 @@ func _process(_delta: float) -> void:
 	var direction: Vector3
 	direction = (_player.transform.basis * Vector3(input_dir.x, 0, input_dir.y)).limit_length()
 	if direction:
-		_move_params.direction = direction
+		# HACK: Rotate the player character's collision shape to match with camera node. This will rotate the mesh as well.
+		# Cursed af, but works for now.
+		var camera_root: Node3D = _player.find_child("CameraRoot")
+		var col_shape: CollisionShape3D = _player.find_child("CollisionShape3D")
+		col_shape.rotation.y = camera_root.rotation.y  # CRITICAL: Doesn't work
+
+		var relative_dir: Vector3 = direction.rotated(Vector3.UP, camera_root.rotation.y)
+		_move_params.direction = relative_dir
 		_move_command.execute(_player, _move_params)
 
 	if Input.is_action_just_pressed("jump"):

--- a/Ikaros/core/scene.gd
+++ b/Ikaros/core/scene.gd
@@ -32,3 +32,4 @@ func attach_camera_to_player() -> void:
 
 	_logger.info("Attaching camera to player.")
 	player.add_child(camera_controller.camera_root)
+	camera_controller.camera_root.set_owner(player)

--- a/Ikaros/game/assets/character.tscn
+++ b/Ikaros/game/assets/character.tscn
@@ -30,6 +30,7 @@ shape = SubResource("CapsuleShape3D_51oe4")
 [node name="MeshInstance3D" type="MeshInstance3D" parent="CollisionShape3D"]
 mesh = SubResource("CapsuleMesh_o4cnb")
 
-[node name="Eyes" type="MeshInstance3D" parent="."]
-transform = Transform3D(0.365473, 0, 0, 0, 0.222278, 0, 0, 0, 0.167722, 0, 1.30116, 0.348212)
+[node name="Eyes" type="MeshInstance3D" parent="CollisionShape3D"]
+transform = Transform3D(0.365473, 0, 0, 0, 0.222278, 0, 0, 0, 0.167722, 0, 0.40116, 0.348212)
 mesh = SubResource("BoxMesh_owsm4")
+skeleton = NodePath("../..")


### PR DESCRIPTION
This PR will add player rotation based on the camera rotation.

In first person the player is always rotated with camera.

In third person the player is only rotated while in motion. While stationary the player is free to look around their model.

Closes #19 